### PR TITLE
addip_linux.go: addIP() minor refine

### DIFF
--- a/addip_linux.go
+++ b/addip_linux.go
@@ -23,17 +23,16 @@ func initLib() (err error) {
 func addIP(ip net.IP, list string) error {
 	p, err := c.Header(list)
 	if err != nil {
-		log.Error("ipsetAddIP(): cannot get ipset %q header: %v", list, err)
 		return err
 	}
 	var typeMatch bool
 	if uint(p.Family.Value) == uint(netfilter.ProtoIPv4) {
-		typeMatch = (ip.To4() != nil)
+		typeMatch = ip.To4() != nil
 	} else if uint(p.Family.Value) == uint(netfilter.ProtoIPv6) {
-		typeMatch = (ip.To16() != nil)
+		typeMatch = ip.To16() != nil
 	}
 	if !typeMatch {
-		return errors.New("Not matched type")
+		return errors.New("not matched type")
 	}
 	AddIPCount.WithLabelValues(list).Add(1)
 	return c.Add(list, goipset.NewEntry(goipset.EntryIP(ip)))


### PR DESCRIPTION
Things done:
- Remove unnecessary logging, since we already returned an error.
- Fix warning `Error string should not be capitalized or end with punctuation'
- Fix warning `Redundant parentheses'